### PR TITLE
Fix for non working links in dasboard

### DIFF
--- a/admin/views/dashboard/tmpl/default.php
+++ b/admin/views/dashboard/tmpl/default.php
@@ -19,7 +19,7 @@ defined ( '_JEXEC' ) or die ( 'Restricted access' );
 						<a class="thumbnail" href="<?php echo JRoute::_('index.php?option='.CJBLOG.'&view=badges');?>">
 							<img src="<?php echo JUri::base(true).'/components/'.CJBLOG.'/assets/images/badges-96px.png'?>" alt="">
 						</a>
-						<span><a href="#"><?php echo JText::_('COM_CJBLOG_BADGES');?></a></span>
+						<span><a href="<?php echo JRoute::_('index.php?option='.CJBLOG.'&view=badges');?>"><?php echo JText::_('COM_CJBLOG_BADGES');?></a></span>
 					</div>
 				</li>
 				<li class="span2">
@@ -27,7 +27,7 @@ defined ( '_JEXEC' ) or die ( 'Restricted access' );
 						<a class="thumbnail" href="<?php echo JRoute::_('index.php?option='.CJBLOG.'&view=badgerules');?>">
 							<img src="<?php echo JUri::base(true).'/components/'.CJBLOG.'/assets/images/badge-rules-96px.png'?>" alt="">
 						</a>
-						<span><a href="#"><?php echo JText::_('COM_CJBLOG_BADGE_RULES');?></a></span>
+						<span><a href="<?php echo JRoute::_('index.php?option='.CJBLOG.'&view=badgerules');?>"><?php echo JText::_('COM_CJBLOG_BADGE_RULES');?></a></span>
 					</div>
 				</li>
 				<li class="span2">
@@ -35,7 +35,7 @@ defined ( '_JEXEC' ) or die ( 'Restricted access' );
 						<a class="thumbnail" href="<?php echo JRoute::_('index.php?option='.CJBLOG.'&view=points');?>">
 							<img src="<?php echo JUri::base(true).'/components/'.CJBLOG.'/assets/images/points-96px.png'?>" alt="">
 						</a>
-						<span><a href="#"><?php echo JText::_('COM_CJBLOG_POINTS');?></a></span>
+						<span><a href="<?php echo JRoute::_('index.php?option='.CJBLOG.'&view=points');?>"><?php echo JText::_('COM_CJBLOG_POINTS');?></a></span>
 					</div>
 				</li>
 				<li class="span2">
@@ -43,7 +43,7 @@ defined ( '_JEXEC' ) or die ( 'Restricted access' );
 						<a class="thumbnail" href="<?php echo JRoute::_('index.php?option='.CJBLOG.'&view=users');?>">
 							<img src="<?php echo JUri::base(true).'/components/'.CJBLOG.'/assets/images/users-96px.png'?>" alt="">
 						</a>
-						<span><a href="#"><?php echo JText::_('COM_CJBLOG_USERS');?></a></span>
+						<span><a href="<?php echo JRoute::_('index.php?option='.CJBLOG.'&view=users');?>"><?php echo JText::_('COM_CJBLOG_USERS');?></a></span>
 					</div>
 				</li>
 			</ul>

--- a/site/helpers/helper.php
+++ b/site/helpers/helper.php
@@ -80,6 +80,13 @@ class CjBlogHelper {
 			: CJBLOG_MEDIA_URI.'images/'.($size >= 160 ? 'thumbnail-big.png' : 'thumbnail-small.png');
 	}
 
+	public static function delete_article_thumbnail($article){
+		if(file_exists(CJBLOG_MEDIA_DIR.'thumbnails/'.$article->id.'_thumb.jpg')) {
+
+			JFile::delete(CJBLOG_MEDIA_DIR.'thumbnails/'.$article->id.'_thumb.jpg');
+		}
+	}
+
 	public static function get_article_thumbnail($article, $size=256){
 	
 		if(!file_exists(CJBLOG_MEDIA_DIR.'thumbnails/'.$article->id.'_thumb.jpg')) {


### PR DESCRIPTION
Hi,
the links under the icons / buttons in the administrator dashboard do not link correct. They have a href # that doesn't work.
This pull request adds the href from the icon also to the text link. Should work :)
